### PR TITLE
Remove dependency on mongo gem since mongoid3 doesn't use it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "http://rubygems.org"
 
 gem 'mongoid'
-gem 'mongo', '~>1.6'
 
 group :development do
   gem "rdoc", "~> 3.12"

--- a/mongoid_colored_logger.gemspec
+++ b/mongoid_colored_logger.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Roman Shterenzon"]
-  s.date = "2013-03-12"
+  s.date = "2013-06-08"
   s.description = "Beautiful logging for Mongoid"
   s.email = "romanbsd@yahoo.com"
   s.extra_rdoc_files = [
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/romanbsd/mongoid_colored_logger"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.23"
+  s.rubygems_version = "1.8.24"
   s.summary = "Beautiful logging for Mongoid"
 
   if s.respond_to? :specification_version then
@@ -40,20 +40,17 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<mongoid>, [">= 0"])
-      s.add_runtime_dependency(%q<mongo>, ["~> 1.6"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.0"])
     else
       s.add_dependency(%q<mongoid>, [">= 0"])
-      s.add_dependency(%q<mongo>, ["~> 1.6"])
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_dependency(%q<bundler>, ["~> 1.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.0"])
     end
   else
     s.add_dependency(%q<mongoid>, [">= 0"])
-    s.add_dependency(%q<mongo>, ["~> 1.6"])
     s.add_dependency(%q<rdoc>, ["~> 3.12"])
     s.add_dependency(%q<bundler>, ["~> 1.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.0"])


### PR DESCRIPTION
Merely removes the direct dependency on the mongo gem for the benefit of mongoid3. Should cause zero issues since mongoid2 still depends on it.
