### PR TITLE
Hotfix require mongoid

### DIFF
--- a/lib/mongoid_colored_logger.rb
+++ b/lib/mongoid_colored_logger.rb
@@ -1,2 +1,1 @@
 require 'mongoid_colored_logger/railtie'
-require 'mongoid'

--- a/lib/mongoid_colored_logger.rb
+++ b/lib/mongoid_colored_logger.rb
@@ -1,1 +1,2 @@
 require 'mongoid_colored_logger/railtie'
+require 'mongoid'

--- a/lib/mongoid_colored_logger/logger_decorator.rb
+++ b/lib/mongoid_colored_logger/logger_decorator.rb
@@ -1,3 +1,5 @@
+require 'mongoid'
+
 module MongoidColoredLogger
   class LoggerDecorator
     WHITE = "\e[37m"


### PR DESCRIPTION
Failing on Rails 4, because `mongoid` is not required.