### PR TITLE
Better integration with Mongoid 5

### DIFF
--- a/lib/mongoid_colored_logger/logger_decorator.rb
+++ b/lib/mongoid_colored_logger/logger_decorator.rb
@@ -59,8 +59,10 @@ module MongoidColoredLogger
         sub(%r{(?<=\]\.)\w+}) {|m| color(m, YELLOW)}
       message.sub('MOPED:', color('MOPED:', odd? ? CYAN : MAGENTA)).
         sub(/\{.+?\}\s/) { |m| color(m, BLUE) }.
-        sub(/COMMAND|QUERY|KILL_CURSORS|INSERT|DELETE|UPDATE|GET_MORE/) { |m| color(m, YELLOW) }.
-        sub(/[\d\.]+ms/) { |m| color(m, GREEN) }
+        sub(/COMMAND|QUERY|KILL_CURSORS|INSERT|DELETE|UPDATE|GET_MORE|STARTED/) { |m| color(m, YELLOW) }.
+        sub(/SUCCEEDED/) { |m| color(m, GREEN) }.
+        sub(/FAILED/) { |m| color(m, RED) }.
+        sub(/[\d\.]+(s|ms)/) { |m| color(m, GREEN) }
     end
 
     def odd?

--- a/lib/mongoid_colored_logger/railtie.rb
+++ b/lib/mongoid_colored_logger/railtie.rb
@@ -4,7 +4,7 @@ module MongoidColoredLogger
 
   class Railtie < Rails::Railtie
     mongoid_version = Mongoid::VERSION.to_f
-    base = mongoid_version >= 3.0 && mongoid_version <= 5.0 ? Moped : config.mongoid
+    base = mongoid_version >= 3.0 && mongoid_version < 5.0 ? Moped : config.mongoid
 
     initializer 'logger_decorator', :after => :initialize_logger do
       base.logger = MongoidColoredLogger::LoggerDecorator.new(Rails.logger)


### PR DESCRIPTION
1. There was an issue when running the Railtie with Mongoid 5.0.2
- caused by `"5.0.2".to_f` returns `5.0`
2. Highlights the runtime for queries