### PR TITLE
Broadcast to STDERR while running console

### DIFF
--- a/lib/mongoid_colored_logger/logger_decorator.rb
+++ b/lib/mongoid_colored_logger/logger_decorator.rb
@@ -20,12 +20,12 @@ module MongoidColoredLogger
 
     colorize_method = Mongoid::VERSION.to_f >= 3.0 ? :colorize_message : :colorize_legacy_message
 
-    %w[debug info warn error fatal unknown].each.with_index do |method, severity|
-      define_method(method) do |message = nil, progname = nil, &block|
+    %w[debug info warn error fatal unknown].each_with_index do |method, severity|
+      define_method(method) do |message = nil, &block|
         message = block.call if message.nil? and block
-        message = self.send(colorize_method, message.to_s)
+        message = send(colorize_method, message.to_s)
 
-        @logger.add(severity, message, progname, &block)
+        @logger.add(severity, nil, message, &block)
       end
     end
 

--- a/lib/mongoid_colored_logger/railtie.rb
+++ b/lib/mongoid_colored_logger/railtie.rb
@@ -12,7 +12,8 @@ module MongoidColoredLogger
 
     # Make it output to STDERR in console
     console do |app|
-      base.logger = MongoidColoredLogger::LoggerDecorator.new(Logger.new(STDERR))
+      console = ActiveSupport::Logger.new(STDERR)
+      Rails.logger.extend ActiveSupport::Logger.broadcast(console)
     end
   end
 end


### PR DESCRIPTION
Hi @romanbsd ,
thank you for the cool gem!

I started using it but I noticed that while working in Rails console colored log goes to `Rails.logger`, i.e. `log/development.log`, but in console directly.

I started a little investigation of how ActiveRecord manages this case (as you know ActiveRecord show colored SQL log in console).

I found the answer in [`ActiveRecord::Railtie`](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/railtie.rb#L50-L57).
Eventually my code is almost copy&paste but it took some time for me to figure it out ☺️ 

So now a log message outputs both in console and `log/development.log`
![image](https://cloud.githubusercontent.com/assets/11523473/24799655/157b2c58-1ba5-11e7-82b6-a38c80a6e6a3.png)
